### PR TITLE
Fix for Incompatible units when unitless value of 0

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -4857,8 +4857,10 @@ class Compiler
                 $unit = $number[2];
                 $originalUnit = $item->unitStr();
             } elseif ($unit !== $number[2]) {
-                $this->throwError('Incompatible units: "%s" and "%s".', $originalUnit, $item->unitStr());
-                break;
+                if ($item->dimension !== '0' || !empty($item->units) || !in_array($originalUnit, ['px', '%'])) {
+                    $this->throwError('Incompatible units: "%s" and "%s".', $originalUnit, $item->unitStr());
+                    break;
+                }
             }
 
             $numbers[$key] = $number;


### PR DESCRIPTION
Only added px and % as cases to fix a particular app error, in case there are some edge case units that would break things. Should probably also include many others, if not all. If it should be all, then the last part of the new `if` statement where it checks the unit can be removed. Since I am not sure, I'm limiting the unit possibilities.

Hopefully this is the right place for this patch.

Getting this error:

    /* Incompatible units: &quot;px&quot; and &quot;&quot;.: line: 76 */

In this SCSS where the other value is computed to px:

    $padding-value: max($padding - $outline-width, 0);

Making it "0px" in the SCSS fixes the error, but I don't think it should be throwing an error at all...